### PR TITLE
[MODIFY] Partial Update for Commission and Chat APIs

### DIFF
--- a/lyc-spring/src/main/java/euclid/lyc_spring/apiPayload/code/status/ErrorStatus.java
+++ b/lyc-spring/src/main/java/euclid/lyc_spring/apiPayload/code/status/ErrorStatus.java
@@ -85,6 +85,7 @@ public enum ErrorStatus implements BaseErrorCode {
     DIRECTOR_EQUAL_MEMBER(HttpStatus.BAD_REQUEST, "COMMISSION4053", "디렉터와 의뢰자가 동일합니다."),
     COMMISSION_CLOTHES_LIST_IS_PRIVATE(HttpStatus.BAD_REQUEST, "COMMISSION4054", "옷 리스트가 비공개 상태입니다."),
     COMMISSION_CLOTHES_LIST_IS_PUBLIC(HttpStatus.BAD_REQUEST, "COMMISSION4055", "옷 리스트가 공개 상태입니다."),
+    COMMISSION_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "COMMISSION4001", "이미 진행중인 의뢰가 있습니다."),
 
     // clothes
     CLOTHES_NOT_FOUND(HttpStatus.NOT_FOUND, "CLOTHES4041", "옷장 게시글이 존재하지 않습니다."),

--- a/lyc-spring/src/main/java/euclid/lyc_spring/controller/CommissionController.java
+++ b/lyc-spring/src/main/java/euclid/lyc_spring/controller/CommissionController.java
@@ -59,8 +59,7 @@ public class CommissionController {
     @Operation(summary = "[구현완료] 의뢰서 확인하기", description = """
             의뢰서의 전체 내용을 확인합니다.
             """)
-    // url이 의뢰함 불러오기랑 겹쳐서 수정함
-    @GetMapping("/chats/commission/{commissionId}")
+    @GetMapping("/chats/commissions/{commissionId}")
     public ApiResponse<CommissionDTO.CommissionInfoDTO> getCommission(@PathVariable Long commissionId) {
         CommissionDTO.CommissionInfoDTO responseDTO = commissionQueryService.getCommission(commissionId);
         return ApiResponse.onSuccess(SuccessStatus._COMMISSION_FETCHED, responseDTO);

--- a/lyc-spring/src/main/java/euclid/lyc_spring/domain/chat/Chat.java
+++ b/lyc-spring/src/main/java/euclid/lyc_spring/domain/chat/Chat.java
@@ -4,6 +4,8 @@ import euclid.lyc_spring.domain.chat.commission.Commission;
 import euclid.lyc_spring.domain.mapping.MemberChat;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -15,6 +17,8 @@ import java.util.List;
 @Getter
 @Entity
 @Builder
+@DynamicInsert
+@DynamicUpdate
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @EntityListeners(AuditingEntityListener.class)
@@ -38,13 +42,14 @@ public class Chat {
     private LocalDateTime inactive;
 
     @Setter
-    @Column
+    @Column(columnDefinition = "INTEGER DEFAULT 0")
     private Integer savedClothesCount;
 
     @Setter
-    @Column
+    @Column(columnDefinition = "BIT DEFAULT 0")
     private Boolean isShared;
 
+    @Setter
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "commission_id", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     private Commission commission;

--- a/lyc-spring/src/main/java/euclid/lyc_spring/dto/request/CommissionRequestDTO.java
+++ b/lyc-spring/src/main/java/euclid/lyc_spring/dto/request/CommissionRequestDTO.java
@@ -12,7 +12,7 @@ public class CommissionRequestDTO {
     @AllArgsConstructor
     public static class CommissionDTO {
 
-        private String directorLoginId;
+        private Long directorId;
         private InfoRequestDTO.BasicInfoDTO basicInfo;
         private StyleRequestDTO.StyleDTO style;
         private InfoRequestDTO.OtherMattersDTO otherMatters;

--- a/lyc-spring/src/main/java/euclid/lyc_spring/dto/response/ChatResponseDTO.java
+++ b/lyc-spring/src/main/java/euclid/lyc_spring/dto/response/ChatResponseDTO.java
@@ -112,12 +112,15 @@ public class ChatResponseDTO {
         private final String nickname;
         private final String profileImage;
         private final Boolean isMine;
+        private final Boolean isDirector;
 
         public static ChatMemberDTO toDTO(MemberChat memberChat, Member member) {
             return ChatMemberDTO.builder()
                     .nickname(memberChat.getMember().getNickname())
                     .profileImage(memberChat.getMember().getProfileImage())
                     .isMine(memberChat.getMember().equals(member))
+                    .isDirector(memberChat.getChat().getCommission().getDirector()
+                            .equals(memberChat.getMember()))
                     .build();
         }
     }
@@ -199,9 +202,13 @@ public class ChatResponseDTO {
     @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
     @Builder(access = AccessLevel.PRIVATE)
     public static class ChatDTO {
+        private final List<ChatMemberDTO> chatMembers;
         private final List<MessageInfoDTO> messages;
-        public static ChatDTO toDTO(List<Message> messages) {
+        public static ChatDTO toDTO(List<Message> messages, Chat chat, Member member) {
             return ChatDTO.builder()
+                    .chatMembers(chat.getMemberChatList().stream()
+                            .map(memberChat -> ChatMemberDTO.toDTO(memberChat, member))
+                            .toList())
                     .messages(messages.stream()
                             .map(MessageInfoDTO::toDTO)
                             .toList())

--- a/lyc-spring/src/main/java/euclid/lyc_spring/repository/commission/CommissionRepository.java
+++ b/lyc-spring/src/main/java/euclid/lyc_spring/repository/commission/CommissionRepository.java
@@ -3,6 +3,7 @@ package euclid.lyc_spring.repository.commission;
 import euclid.lyc_spring.domain.Member;
 import euclid.lyc_spring.domain.chat.Chat;
 import euclid.lyc_spring.domain.chat.commission.Commission;
+import euclid.lyc_spring.domain.enums.CommissionStatus;
 import euclid.lyc_spring.repository.querydsl.CommissionRepositoryCustom;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -15,4 +16,5 @@ public interface CommissionRepository extends JpaRepository<Commission, Long>, C
 
     public List<Commission> findByDirector(Member director);
     public Optional<Commission> findByChat(Chat chat);
+    Optional<Commission> findByDirectorIdAndMemberIdAndStatusNot(Long id, Long id1, CommissionStatus commissionStatus);
 }

--- a/lyc-spring/src/main/java/euclid/lyc_spring/repository/querydsl/ChatRepositoryCustom.java
+++ b/lyc-spring/src/main/java/euclid/lyc_spring/repository/querydsl/ChatRepositoryCustom.java
@@ -1,11 +1,15 @@
 package euclid.lyc_spring.repository.querydsl;
 
+import euclid.lyc_spring.domain.chat.Chat;
 import euclid.lyc_spring.dto.response.ChatResponseDTO;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ChatRepositoryCustom {
 
 
     List<ChatResponseDTO.ChatPreviewDTO> searchChats(String keyword, Long loginId);
+
+    Optional<Chat> findByChatMembers(Long id1, Long id2);
 }

--- a/lyc-spring/src/main/java/euclid/lyc_spring/repository/querydsl/impl/ChatRepositoryCustomImpl.java
+++ b/lyc-spring/src/main/java/euclid/lyc_spring/repository/querydsl/impl/ChatRepositoryCustomImpl.java
@@ -4,14 +4,17 @@ import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import euclid.lyc_spring.domain.QMember;
+import euclid.lyc_spring.domain.chat.Chat;
 import euclid.lyc_spring.domain.chat.QChat;
 import euclid.lyc_spring.domain.chat.QMessage;
+import euclid.lyc_spring.domain.chat.commission.QCommission;
 import euclid.lyc_spring.domain.mapping.QMemberChat;
 import euclid.lyc_spring.dto.response.ChatResponseDTO;
 import euclid.lyc_spring.repository.querydsl.ChatRepositoryCustom;
 import lombok.RequiredArgsConstructor;
 
 import java.util.List;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 public class ChatRepositoryCustomImpl implements ChatRepositoryCustom {
@@ -54,5 +57,19 @@ public class ChatRepositoryCustomImpl implements ChatRepositoryCustom {
                                 .or(member.loginId.containsIgnoreCase(keyword))
                 )
                 .fetch();
+    }
+
+    @Override
+    public Optional<Chat> findByChatMembers(Long id1, Long id2) {
+        QChat chat = QChat.chat;
+        QCommission commission = QCommission.commission;
+
+        return Optional.ofNullable(queryFactory.selectFrom(chat)
+                .join(commission).on(commission.chat.id.eq(chat.id))
+                .where((commission.director.id.eq(id1)
+                        .and(commission.member.id.eq(id2)))
+                        .or(commission.director.id.eq(id2))
+                        .and(commission.member.id.eq(id1)))
+                .fetchFirst());
     }
 }

--- a/lyc-spring/src/main/java/euclid/lyc_spring/service/chat/ChatQueryServiceImpl.java
+++ b/lyc-spring/src/main/java/euclid/lyc_spring/service/chat/ChatQueryServiceImpl.java
@@ -183,7 +183,7 @@ public class ChatQueryServiceImpl implements ChatQueryService {
         String loginId = SecurityUtils.getAuthorizedLoginId();
         Member member = memberRepository.findByLoginId(loginId)
                 .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
-        chatRepository.findByIdAndInactive(chatId, null)
+        Chat chat = chatRepository.findByIdAndInactive(chatId, null)
                 .orElseThrow(() -> new ChatHandler(ErrorStatus.CHAT_NOT_FOUND));
 
         // 채팅에 참여 중인 회원만 채팅방 조회 가능
@@ -206,6 +206,6 @@ public class ChatQueryServiceImpl implements ChatQueryService {
 
         List<Message> messages = messageRepository.findMessagesByChatId(chatId, pageSize, cursorDateTime);
 
-        return ChatResponseDTO.ChatDTO.toDTO(messages);
+        return ChatResponseDTO.ChatDTO.toDTO(messages, chat, member);
     }
 }


### PR DESCRIPTION
# 📌 Pull Request
> **Issue Number**
- #96 

### Works
* 의뢰서 작성 & 수정 시 loginId 대신 memberId 받도록 수정
* 채팅방 조회 시 채팅에 참여중인 회원 정보(+ isMine, isDirector)도 함께 반환하도록 수정
* 의뢰가 진행중인 경우(의뢰 요청 상태, 의뢰 승인, 의뢰 종료 대기 상태) 새로운 의뢰를 생성할 수 없도록 수정
* 의뢰서 작성 시 양 당사자간 채팅방이 이미 존재하는 경우 해당 채팅방을 그대로 활용하도록 수정

***

Pull Request 요청자
|---|
|<div align="center"><img src="https://contrib.rocks/image?repo=dvlp-sy/dvlp-sy" /></div>|
|<div align="center">변시윤</div>|
